### PR TITLE
bootstrap: don't install .gitignore and .gitatributes

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -5,6 +5,7 @@ git pull origin master
 function doIt() {
 	rsync --exclude ".git/" --exclude ".DS_Store" --exclude "bootstrap.sh" \
         --exclude "README.md" --exclude "firstInstall.sh" \
+        --exclude ".gitignore" --exclude ".gitattributes" \
         --exclude "LICENSE-MIT.txt" -avhi --no-perms . ~
 	source ~/.bash_profile
 }
@@ -12,6 +13,7 @@ function doIt() {
 function dryRun() {
 	rsync --exclude ".git/" --exclude ".DS_Store" --exclude "bootstrap.sh" \
         --exclude "README.md" --exclude "firstInstall.sh" \
+        --exclude ".gitignore" --exclude ".gitattributes" \
         --exclude "LICENSE-MIT.txt" -avhni --no-perms . ~
 	source ~/.bash_profile
 }


### PR DESCRIPTION
These local git files should not be rsync'ed to $HOME.

What about .gitconfig? I see that it contains valuable additions. On the other hand i find it very uncomfortable that settings like user.name or user.email are always reset...
