### PR TITLE
fix colors for tty

### DIFF
--- a/.bash_prompt
+++ b/.bash_prompt
@@ -52,10 +52,12 @@ prompt_command()
     userOrHostExtra="\[$user_color\]:"
   fi
 
-  if [[ -n $remote ]] && [[ $COLORTERM = gnome-* && $TERM = xterm ]] && infocmp gnome-256color >/dev/null 2>&1; then
-    export TERM='gnome-256color'
-  elif infocmp xterm-256color >/dev/null 2>&1; then
-    export TERM='xterm-256color'
+  if [[ "$(tty)" == /dev/pts/* ]]; then
+    if [[ -n $remote ]] && [[ $COLORTERM = gnome-* && $TERM = xterm ]] && infocmp gnome-256color >/dev/null 2>&1; then
+      export TERM='gnome-256color'
+    elif infocmp xterm-256color >/dev/null 2>&1; then
+      export TERM='xterm-256color'
+    fi
   fi
 
   local SCM=""

--- a/.colors
+++ b/.colors
@@ -81,3 +81,21 @@ export COLOR_BG_HI_PURPLE='\e[10;95m'  # Purple
 export COLOR_BG_HI_CYAN='\e[0;106m'    # Cyan
 export COLOR_BG_HI_WHITE='\e[0;107m'   # White
 
+if [ "$TERM" = "linux" ]; then
+    echo -en "\e]P0000000" #black
+    echo -en "\e]P82B2B2B" #darkgrey
+    echo -en "\e]P1D75F5F" #darkred
+    echo -en "\e]P9E33636" #red
+    echo -en "\e]P287AF5F" #darkgreen
+    echo -en "\e]PA98E34D" #green
+    echo -en "\e]P3D7AF87" #brown
+    echo -en "\e]PBFFD75F" #yellow
+    echo -en "\e]P48787AF" #darkblue
+    echo -en "\e]PC7373C9" #blue
+    echo -en "\e]P5BD53A5" #darkmagenta
+    echo -en "\e]PDD633B2" #magenta
+    echo -en "\e]P65FAFAF" #darkcyan
+    echo -en "\e]PE44C9C9" #cyan
+    echo -en "\e]P7E5E5E5" #lightgrey
+    echo -en "\e]PFFFFFFF" #white
+fi

--- a/.vimrc
+++ b/.vimrc
@@ -223,16 +223,16 @@ set lazyredraw
 
 " switch syntax highlighting on, when the terminal has colors
 if &t_Co > 2 || has("gui_running")
+  " set the color-theme
+  "let g:solarized_termcolors=256
+  colorscheme molokai
+
   " Enable coloring for dark background terminals.
   if has('gui_running')
     set background=light
   else
     set background=dark
   endif
-
-  " set the color-theme
-  "let g:solarized_termcolors=256
-  colorscheme molokai
 
   " turn on color syntax highlighting
   if exists("+syntax")
@@ -242,7 +242,7 @@ if &t_Co > 2 || has("gui_running")
   syn sync fromstart
 
   " set to 256 colors
-  set t_Co=256
+  " set t_Co=256
 
   " Also switch on highlighting the last used search pattern.
   if exists("+hlsearch")


### PR DESCRIPTION
- .bash_prompt: do not modify the TERM for tty. It should stay as "linux".
- .colors: modify color tones for tty (framebuffer only?). DarkBlue which is used for directories was nearly unreadable.
- .vimrc: now also for tty
