### PR TITLE
fix vim mapping Ctrl-Space for backward search

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -541,7 +541,7 @@ nnoremap k gk
 
 " Map <Space> to / (search) and Ctrl-<Space> to ? (backwards search)
 map <space> /
-map <c-space> ?
+map <C-space> ?
 
 " Disable highlight when <leader><cr> is pressed
 map <silent> <leader><cr> :noh<cr>


### PR DESCRIPTION
In der .vimrc war das c kleingeschrieben, darum funktionierte die Tastenkombination Ctrl-Space nicht für die Rückwrtssuche.