### PR TITLE
Match colors of bash-git-prompt with those used in git status

### DIFF
--- a/.redpill/bash_prompt/themes/voku.bgptheme
+++ b/.redpill/bash_prompt/themes/voku.bgptheme
@@ -52,7 +52,8 @@ override_git_prompt_colors() {
   fi
 
   GIT_PROMPT_THEME_NAME="voku"
-  GIT_PROMPT_STAGED="${Yellow}+"
+  GIT_PROMPT_STAGED="${Green}+"
+  GIT_PROMPT_CHANGED="${Yellow} +"
   GIT_PROMPT_UNTRACKED="${Cyan}?"
   GIT_PROMPT_STASHED="${BoldMagenta}!"
   GIT_PROMPT_CLEAN="${Green}${ICON_FOR_TRUE}"


### PR DESCRIPTION
git status shows "staged" files green and "unstaged" files in yellow. Let's do the same on the prompt?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/voku/dotfiles/19)
<!-- Reviewable:end -->
