### PR TITLE
bash-git-prompt: Warn about bad autocrlf / filemode on cygwin

### DIFF
--- a/.functions
+++ b/.functions
@@ -1385,6 +1385,23 @@ shellShockCheck()
 }
 
 # -------------------------------------------------------------------
+# callback for bash-git-prompt
+prompt_callback()
+{
+  if [[ $SYSTEM_TYPE == "CYGWIN" || $SYSTEM_TYPE == "MINGW" ]]; then
+    if [[ $(git config --get core.autocrlf) != "true" ]]; then
+      s=" CRLF";
+    fi
+    if [[ $(git config --get core.filemode) != "false" ]]; then
+      s+=" FILEMODE";
+    fi
+    if [[ -n $s ]]; then
+      echo "${COLOR_RED}${s}${COLOR_NO_COLOUR}";
+    fi
+  fi
+}
+
+# -------------------------------------------------------------------
 # git_prompt for PS1
 __git_prompt()
 {


### PR DESCRIPTION
Do you think this is the right place to implement?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/voku/dotfiles/21)
<!-- Reviewable:end -->
