### PR TITLE
git clone: Automatic configuration of user.email / user.name based on url pattern

### DIFF
--- a/.git-templates/hooks/post-checkout
+++ b/.git-templates/hooks/post-checkout
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+#checkout hook to locally set user name and email based on user defined patterns
+#The patterns are matched against the clone url.
+#
+#Based on http://www.dvratil.cz/2015/12/git-trick-628-automatically-set-commit-author-based-on-repo-url/
+
+function warn {
+  echo -e "\n$1 Email and author not initialized!"
+  echo -e "You can define them manually in the local config or run\n\n    git config --local user.disable true\n\nto get rid of this warning."
+}
+
+email="$(git config --local user.email)"
+name="$(git config --local user.name)"
+disable="$(git config --local user.disable)"
+
+if [[ -n $email || -n $name || $disable == "true" ]]; then
+  exit 0
+fi
+
+#get remote name:
+#  only one: take it
+#  more: take "origin", or fail
+remote="$([[ $(git remote | wc -l) -eq 1 ]] && git remote || git remote | grep "^origin$")"
+
+if [[ -z $remote ]]; then
+  warn "Failed to detect remote."
+  exit 0
+fi
+
+url="$(git config --local remote.${remote}.url)"
+
+if [[ ! -f ~/.git-clone-init ]]; then
+cat << INPUT > ~/.git-clone-init
+#!/bin/bash
+
+case "\$url" in
+  *@github.com:*    ) email=""; name="";;
+  *//github.com/*   ) email=""; name="";;
+esac
+INPUT
+  echo -e "\nMissing file ~/.git-clone-init. Template created..."
+  echo -e "Edit this file and run \n\n    git checkout\n\nfrom within the cloned repository."
+  exit 0
+fi
+. ~/.git-clone-init
+
+if [[ -z $name || -z $email ]]; then
+  warn "Failed to detect identity using ~/.git-clone-init."
+  exit 0
+fi
+
+git config --local user.email "$email"
+git config --local user.name "$name"
+
+echo "Identitiy set to $name <$email>"

--- a/.gitconfig
+++ b/.gitconfig
@@ -447,5 +447,8 @@
 [hub]
   protocol = https
 
+[init]
+  templatedir = ~/.git-templates
+
 [include]
   path = .gitconfig.extra


### PR DESCRIPTION
Ever been in the situation of not being aware of a wrong configured user.email and pushing it to github? Happend to me recently and based on the idea on 

http://www.dvratil.cz/2015/12/git-trick-628-automatically-set-commit-author-based-on-repo-url/

I implemented a solution in bash shell. A clone will look like this:

> $ git clone git@github.com:DrVanScott/dotfiles.git
> Cloning into 'dotfile'...
> remote: Counting objects: 6468, done.
> remote: Compressing objects: 100% (4/4), done.
> remote: Total 6468 (delta 0), reused 0 (delta 0), pack-reused 6462
> Receiving objects: 100% (6468/6468), 9.48 MiB | 1.51 MiB/s, done.
> Resolving deltas: 100% (3069/3069), done.
> Checking connectivity... done.
> _Identitiy set to DrVanScott <mymail@myserver.de>_
(last line)

The configuration file ~/.git-clone-init looks like

    case "$url" in
      *@github.com:*    ) email="mymail@myserver.de"; name="DrVanScott";;
      *//github.com/*   ) email="mymail@myserver.de"; name="DrVanScott";;
    esac

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/voku/dotfiles/23)
<!-- Reviewable:end -->
