### PR TITLE
fix ALT key mappings for terminals generating escape sequences

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -33,6 +33,19 @@
 " => General
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
+" Simulate ALT-<key> by mapping escape sequences to key combination. This is
+" required for terminals which do not send ALT combinations in 8-bit.
+" See http://stackoverflow.com/questions/6778961/alt-key-shortcuts-not-working-on-gnome-terminal-with-vim/10216459#10216459
+" this applies also to cygwin's mintty.
+let c='a'
+while c <= 'z'
+  exec "set <A-".c.">=\e".c
+  exec "imap \e".c." <A-".c.">"
+  let c = nr2char(1+char2nr(c))
+endw
+
+set ttimeout ttimeoutlen=25 "this is the timeout to distinguish e.g. <A-k> from 'ESC <timeout> k'
+
 " make Vim more useful
 set nocompatible
 


### PR DESCRIPTION
Just recognized that some mappings of .vimrc do not work in cygwin, e.g. \<M-j\> (which is synonym for \<A-j\>). This PR fixes this for at least mintty.

Need to be tested in other environments. Do you understand the difference betwenn

    set timeout ttimeoutlen=50

and

    set ttimeout ttimeoutlen=50

as described in http://stackoverflow.com/a/10216459/2910279 ?
For me, the later seems to be more restrictive, so i've choosen that...
The current solution only maps the lowercase combinations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/voku/dotfiles/28)
<!-- Reviewable:end -->
