### PR TITLE
Add python3 support for gundo.vim

### DIFF
--- a/.vimrc.bundles
+++ b/.vimrc.bundles
@@ -37,6 +37,10 @@ Bundle 'sjl/gundo.vim'
 " Toggle the history-menu with "<F5>".
 nnoremap <F5> :GundoToggle<CR>
 
+if has('python3')
+  let g:gundo_prefer_python3 = 1
+endif
+
 " ----------------------------------------
 
 "Bundle 'tpope/vim-surround'


### PR DESCRIPTION
Allows to use sjl/gundo.vim with vim compiled with python3

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/voku/dotfiles/40)
<!-- Reviewable:end -->
